### PR TITLE
Potential fix for code scanning alert no. 73: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/04768080731/juice-shop-ada-1497/security/code-scanning/73](https://github.com/04768080731/juice-shop-ada-1497/security/code-scanning/73)

The best way to fix the problem is to avoid using the `$where` operator with user-controlled input entirely. Instead, use strict query objects that match the intended field and value directly. In MongoDB, to search for orders with a given `orderId`, use `{ orderId: id }` as the query object instead of interpreting JavaScript code with `$where`. This avoids any possibility for code injection and is more efficient. The only necessary code change is to replace the `$where` usage with a direct query. No changes to imports or other code are required, and all existing logic remains the same.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
