### PR TITLE
Potential fix for code scanning alert no. 65: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -18,7 +18,9 @@ class ErrorWithParent extends Error {
 // vuln-code-snippet start unionSqlInjectionChallenge dbSchemaChallenge
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
-    let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    let criteria: string = typeof req.query.q === 'string'
+      ? (req.query.q === 'undefined' ? '' : req.query.q)
+      : ''
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/04768080731/juice-shop-ada-1497/security/code-scanning/65](https://github.com/04768080731/juice-shop-ada-1497/security/code-scanning/65)

The problem is that the parameter `req.query.q` is assumed to always be a string, but in Express.js it can be an array or undefined. We should check at runtime whether it is a string before using string methods like `.length` and `.substring`. For security, if it is not a string, we should treat it as invalid input or coerce it to a safe default (such as an empty string), or return a 400 error, depending on the intended UX. Here, to maintain existing functionality, we'll treat non-string input as the empty string.

Edit `routes/search.ts`:
- Update the assignment to `criteria` on line 21 so that it is only taken from `req.query.q` if it is a string; otherwise, it is set to `''`.
- The length and substring operations will then safely work with strings.

No new imports are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
